### PR TITLE
feat<Common>: 기본 화면 레이아웃 세팅 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { Logo, NavigationBar } from '@/shared/ui'
 
 export const metadata: Metadata = {
   title: 'HINKOR',
@@ -13,7 +14,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <div className="flex justify-center">
+          <div className="max-w-3xl w-full bg-white p-5">
+            <Logo />
+            <NavigationBar />
+            {children}
+            <footer className="mt-3 text-xs text-gray-400 text-center">
+              All rights reserved by JeongJooKim
+            </footer>
+          </div>
+        </div>
+      </body>
     </html>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "hinkor",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "lint-staged": "^16.2.7",
         "next": "16.0.6",
         "react": "19.2.0",
-        "react-dom": "19.2.0"
+        "react-dom": "19.2.0",
+        "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2640,6 +2642,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6404,6 +6415,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "lint-staged": "^16.2.7",
     "next": "16.0.6",
     "react": "19.2.0",
-    "react-dom": "19.2.0"
+    "react-dom": "19.2.0",
+    "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/shared/lib/classMerge.ts
+++ b/shared/lib/classMerge.ts
@@ -1,0 +1,8 @@
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+type ClassValue = Parameters<typeof clsx>[0]
+
+export function classMerge(...inputs: ClassValue[]) {
+  return twMerge(clsx(...inputs))
+}

--- a/shared/lib/index.ts
+++ b/shared/lib/index.ts
@@ -1,0 +1,1 @@
+export { classMerge } from './classMerge'

--- a/shared/ui/Logo.tsx
+++ b/shared/ui/Logo.tsx
@@ -1,0 +1,8 @@
+export default function Logo() {
+  return (
+    <div className="flex gap-1 text-2xl font-bold font-hinko mb-5">
+      <h1 className="text-accent">HIN</h1>
+      <h1 className="text-primary">KOR</h1>
+    </div>
+  )
+}

--- a/shared/ui/NavigationBar.tsx
+++ b/shared/ui/NavigationBar.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState } from 'react'
+import NavigationButton from './NavigationButton'
+
+const menu = [
+  {
+    label: 'Day',
+    isActive: true,
+  },
+  {
+    label: 'Theme',
+    isActive: false,
+  },
+  {
+    label: 'Quiz',
+    isActive: false,
+  },
+]
+
+export default function NavigationBar() {
+  const [navigation, setNavigation] = useState(menu)
+
+  const handleNavigation = (label: string) => {
+    const updated = navigation.map((item) => ({ ...item, isActive: item.label === label }))
+    setNavigation(updated)
+  }
+
+  return (
+    <div className="flex gap-2">
+      {navigation.map((item) => (
+        <NavigationButton
+          key={item.label}
+          label={item.label}
+          isActive={item.isActive}
+          onClick={handleNavigation}
+        />
+      ))}
+    </div>
+  )
+}

--- a/shared/ui/NavigationButton.tsx
+++ b/shared/ui/NavigationButton.tsx
@@ -1,0 +1,21 @@
+import { twMerge } from 'tailwind-merge'
+
+interface Props {
+  label: string
+  isActive: boolean
+  onClick: (label: string) => void
+}
+
+export default function NavigationButton({ label, isActive, onClick }: Props) {
+  return (
+    <button
+      className={twMerge(
+        'bg-gray-200 rounded-t-md px-4 py-1 text-base font-bold hover:bg-gray-400 hover:cursor-pointer',
+        isActive && 'text-white bg-primary ',
+      )}
+      onClick={() => onClick(label)}
+    >
+      {label}
+    </button>
+  )
+}

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -1,0 +1,2 @@
+export { default as Logo } from './Logo'
+export { default as NavigationBar } from './NavigationBar'


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- Tailwind 클래스 충돌 방지를 위한 classMerge 헬퍼 추가
- 전체 화면 레이아웃 추가 

## 관련 이슈
- close #5 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
### Tailwind 클래스 충돌 방지를 위한 classMerge 헬퍼 추가
**헬퍼함수가 필요한 이유**
- 단순 문자열로 className을 쓰면 if 조건 및 삼항 연산자가 난무하게 됨 

**clsx 설치한 이유**
- 복잡한 삼항 연산자나 문자열 더하기 대신, boolean 상태 기반으로 깔끔하게 class를 정리할 수 있기 때문

**tailwind-merge 설치 이유** 
-  tailwind 유틸리티 클래스 충돌을 자동으로 해결하기 위해 사용

### 전체 화면 레이아웃 추가 
- layout.tsx 에 로고, 네비게이션 바 추가
- 네비게이션에 라우팅 추가해야됨 
