### PR TITLE
feat<Routing>: 페이지별 UI 컴포넌트화 및 헤더 구조 개선

### DIFF
--- a/app/day/page.tsx
+++ b/app/day/page.tsx
@@ -1,5 +1,10 @@
 import { WordItem } from '@/widgets/word-list-container'
 
+export const metadata = {
+  title: '날짜',
+  description: '힌디어 단어장 - 날짜별 목록입니다',
+}
+
 export default function DayPage() {
   return (
     <div className="flex flex-col gap-3 p-3 bg-white rounded-b-md rounded-r-md border border-gray-200">

--- a/app/day/page.tsx
+++ b/app/day/page.tsx
@@ -1,0 +1,10 @@
+import { WordItem } from '@/widgets/word-list-container'
+
+export default function DayPage() {
+  return (
+    <div className="flex flex-col gap-3 p-3 bg-white rounded-b-md rounded-r-md border border-gray-200">
+      <WordItem />
+      <WordItem />
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,10 @@ import './globals.css'
 import { Header, NavigationBar } from '@/shared/ui'
 
 export const metadata: Metadata = {
-  title: 'HINKOR',
+  title: {
+    default: 'HINKOR | 힌디어 단어장',
+    template: '%s | 힌디어 단어장',
+  },
   description: '힌디어 단어장',
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <div className="flex justify-center">
-          <div className="max-w-3xl w-full bg-white p-5">
+          <div className="max-w-3xl w-full bg-white p-5 min-h-screen">
             <Logo />
             <NavigationBar />
             {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
-import { Logo, NavigationBar } from '@/shared/ui'
+import { Header, NavigationBar } from '@/shared/ui'
 
 export const metadata: Metadata = {
   title: 'HINKOR',
@@ -17,7 +17,8 @@ export default function RootLayout({
       <body>
         <div className="flex justify-center">
           <div className="max-w-3xl w-full bg-white p-5 min-h-screen">
-            <Logo />
+            {/* params가 있으면 로고 대신 뒤로 가는 버튼 있어야됨 */}
+            <Header />
             <NavigationBar />
             {children}
             <footer className="mt-3 text-xs text-gray-400 text-center">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { Header, NavigationBar } from '@/shared/ui'
+import { Suspense } from 'react'
 
 export const metadata: Metadata = {
   title: {
@@ -20,8 +21,10 @@ export default function RootLayout({
       <body>
         <div className="flex justify-center">
           <div className="max-w-3xl w-full bg-white p-5 min-h-screen">
-            {/* params가 있으면 로고 대신 뒤로 가는 버튼 있어야됨 */}
-            <Header />
+            <Suspense fallback={null}>
+              <Header />
+            </Suspense>
+
             <NavigationBar />
             {children}
             <footer className="mt-3 text-xs text-gray-400 text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import { CategoryButton } from '@/widgets/category-container'
 
-export default function Home() {
+export default function DayPage() {
   return (
     <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
       <CategoryButton />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { CategoryButton } from '@/widgets/category-container'
 export default function DayPage() {
   return (
     <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
-      <CategoryButton />
+      <CategoryButton label="day1" />
     </div>
   )
 }

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -1,6 +1,11 @@
 import { CategoryButton } from '@/widgets/category-container'
 import { AnswerItem, QuizItem } from '@/widgets/quiz-container'
 
+export const metadata = {
+  title: '퀴즈',
+  description: '힌디어 단어장 - 퀴즈 목록입니다',
+}
+
 export default async function QuizPage({ searchParams }: { searchParams: { id?: string } }) {
   const params = await searchParams
   const isParams = params.id ? true : false

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -1,0 +1,12 @@
+import { AnswerItem, QuizItem } from '@/widgets/quiz-container'
+
+export default function QuizPage() {
+  return (
+    <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
+      <div className="flex flex-col items-center justify-center gap-4">
+        <QuizItem />
+        <AnswerItem />
+      </div>
+    </div>
+  )
+}

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -1,12 +1,20 @@
+import { CategoryButton } from '@/widgets/category-container'
 import { AnswerItem, QuizItem } from '@/widgets/quiz-container'
 
-export default function QuizPage() {
+export default async function QuizPage({ searchParams }: { searchParams: { id?: string } }) {
+  const params = await searchParams
+  const isParams = params.id ? true : false
+
   return (
     <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
-      <div className="flex flex-col items-center justify-center gap-4">
-        <QuizItem />
-        <AnswerItem />
-      </div>
+      {isParams ? (
+        <div className="flex flex-col  gap-3 items-center justify-center">
+          <QuizItem />
+          <AnswerItem />
+        </div>
+      ) : (
+        <CategoryButton label="퀴즈" />
+      )}
     </div>
   )
 }

--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -1,9 +1,19 @@
 import { CategoryButton } from '@/widgets/category-container'
+import { WordItem } from '@/widgets/word-list-container'
+import { twMerge } from 'tailwind-merge'
 
-export default function ThemePage() {
+export default async function ThemePage({ searchParams }: { searchParams: { id?: string } }) {
+  const params = await searchParams
+  const isParams = params.id ? true : false
+
   return (
-    <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
-      <CategoryButton />
+    <div
+      className={twMerge(
+        'flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md',
+        isParams && 'bg-white border border-gray-200',
+      )}
+    >
+      {isParams ? <WordItem /> : <CategoryButton label="사랑" />}
     </div>
   )
 }

--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -1,6 +1,10 @@
 import { CategoryButton } from '@/widgets/category-container'
 import { WordItem } from '@/widgets/word-list-container'
 import { twMerge } from 'tailwind-merge'
+export const metadata = {
+  title: '테마',
+  description: '힌디어 단어장 - 테마 목록입니다',
+}
 
 export default async function ThemePage({ searchParams }: { searchParams: { id?: string } }) {
   const params = await searchParams

--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -1,6 +1,6 @@
 import { CategoryButton } from '@/widgets/category-container'
 
-export default function Home() {
+export default function ThemePage() {
   return (
     <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
       <CategoryButton />

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "lint-staged": "^16.2.7",
+        "lucide-react": "^0.555.0",
         "next": "16.0.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
@@ -5064,6 +5065,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.555.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
+      "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "lint-staged": "^16.2.7",
+    "lucide-react": "^0.555.0",
     "next": "16.0.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/shared/ui/Header.tsx
+++ b/shared/ui/Header.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { X } from 'lucide-react'
+
+export default function Header() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const isDetailPage = searchParams.get('id')
+
+  return (
+    <div>
+      {isDetailPage ? (
+        <div className="flex w-full justify-end">
+          <button onClick={() => router.back()}>
+            <X className="w-6" />
+          </button>
+        </div>
+      ) : (
+        <div className="flex gap-1 text-2xl font-bold font-hinko mb-4">
+          <h1 className="text-accent">HIN</h1>
+          <h1 className="text-primary">KOR</h1>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/shared/ui/Logo.tsx
+++ b/shared/ui/Logo.tsx
@@ -1,6 +1,6 @@
 export default function Logo() {
   return (
-    <div className="flex gap-1 text-2xl font-bold font-hinko mb-5">
+    <div className="flex gap-1 text-2xl font-bold font-hinko mb-4">
       <h1 className="text-accent">HIN</h1>
       <h1 className="text-primary">KOR</h1>
     </div>

--- a/shared/ui/Logo.tsx
+++ b/shared/ui/Logo.tsx
@@ -1,8 +1,0 @@
-export default function Logo() {
-  return (
-    <div className="flex gap-1 text-2xl font-bold font-hinko mb-4">
-      <h1 className="text-accent">HIN</h1>
-      <h1 className="text-primary">KOR</h1>
-    </div>
-  )
-}

--- a/shared/ui/NavigationBar.tsx
+++ b/shared/ui/NavigationBar.tsx
@@ -1,28 +1,35 @@
 'use client'
 import { useState } from 'react'
 import NavigationButton from './NavigationButton'
+import { useRouter } from 'next/navigation'
 
 const menu = [
   {
-    label: 'Day',
+    label: 'DAY',
     isActive: true,
   },
   {
-    label: 'Theme',
+    label: 'THEME',
     isActive: false,
   },
   {
-    label: 'Quiz',
+    label: 'QUIZ',
     isActive: false,
   },
 ]
 
 export default function NavigationBar() {
   const [navigation, setNavigation] = useState(menu)
+  const router = useRouter()
 
   const handleNavigation = (label: string) => {
     const updated = navigation.map((item) => ({ ...item, isActive: item.label === label }))
     setNavigation(updated)
+    if (label === 'DAY') {
+      router.push(`/`)
+    } else {
+      router.push(`/${label.toLowerCase()}`)
+    }
   }
 
   return (

--- a/shared/ui/UndoButton.tsx
+++ b/shared/ui/UndoButton.tsx
@@ -1,6 +1,0 @@
-import { X } from 'lucide-react'
-
-function UndoButton() {
-  return <X className="w-6" />
-}
-export default UndoButton

--- a/shared/ui/UndoButton.tsx
+++ b/shared/ui/UndoButton.tsx
@@ -1,0 +1,6 @@
+import { X } from 'lucide-react'
+
+function UndoButton() {
+  return <X className="w-6" />
+}
+export default UndoButton

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as Logo } from './Logo'
 export { default as NavigationBar } from './NavigationBar'
+export { default as UndoButton } from './UndoButton'

--- a/shared/ui/index.ts
+++ b/shared/ui/index.ts
@@ -1,3 +1,2 @@
-export { default as Logo } from './Logo'
+export { default as Header } from './Header'
 export { default as NavigationBar } from './NavigationBar'
-export { default as UndoButton } from './UndoButton'

--- a/widgets/category-container/index.ts
+++ b/widgets/category-container/index.ts
@@ -1,0 +1,1 @@
+export { default as CategoryButton } from './ui/CategoryButton'

--- a/widgets/category-container/ui/CategoryButton.tsx
+++ b/widgets/category-container/ui/CategoryButton.tsx
@@ -1,0 +1,10 @@
+import { ChevronRight } from 'lucide-react'
+
+export default function CategoryButton() {
+  return (
+    <div className="flex bg-white rounded-md p-2 justify-between items-center border border-gray-100">
+      day1
+      <ChevronRight size={20} />
+    </div>
+  )
+}

--- a/widgets/category-container/ui/CategoryButton.tsx
+++ b/widgets/category-container/ui/CategoryButton.tsx
@@ -1,10 +1,26 @@
+'use client'
 import { ChevronRight } from 'lucide-react'
+import { usePathname, useRouter } from 'next/navigation'
 
 export default function CategoryButton() {
+  const router = useRouter()
+  const path = usePathname()
+
+  const goToDetailPage = () => {
+    if (path === '/theme') {
+      router.push('/theme?=1')
+    } else {
+      router.push('/day?=1')
+    }
+  }
+
   return (
-    <div className="flex bg-white rounded-md p-2 justify-between items-center border border-gray-100">
+    <button
+      className="flex bg-white rounded-md p-2 justify-between items-center border border-gray-100"
+      onClick={goToDetailPage}
+    >
       day1
       <ChevronRight size={20} />
-    </div>
+    </button>
   )
 }

--- a/widgets/category-container/ui/CategoryButton.tsx
+++ b/widgets/category-container/ui/CategoryButton.tsx
@@ -2,15 +2,21 @@
 import { ChevronRight } from 'lucide-react'
 import { usePathname, useRouter } from 'next/navigation'
 
-export default function CategoryButton() {
+interface Props {
+  label: string
+}
+
+export default function CategoryButton({ label }: Props) {
   const router = useRouter()
   const path = usePathname()
 
   const goToDetailPage = () => {
     if (path === '/theme') {
-      router.push('/theme?=1')
-    } else {
-      router.push('/day?=1')
+      router.push(`/theme?id=${1}`)
+    } else if (path === '/') {
+      router.push(`/day?id=${1}`)
+    } else if (path === '/quiz') {
+      router.push(`/quiz?id=${1}`)
     }
   }
 
@@ -19,7 +25,7 @@ export default function CategoryButton() {
       className="flex bg-white rounded-md p-2 justify-between items-center border border-gray-100"
       onClick={goToDetailPage}
     >
-      day1
+      {label}
       <ChevronRight size={20} />
     </button>
   )

--- a/widgets/quiz-container/index.ts
+++ b/widgets/quiz-container/index.ts
@@ -1,0 +1,2 @@
+export { default as QuizItem } from './ui/QuizItem'
+export { default as AnswerItem } from './ui/AnswerItem'

--- a/widgets/quiz-container/ui/AnswerItem.tsx
+++ b/widgets/quiz-container/ui/AnswerItem.tsx
@@ -1,0 +1,10 @@
+export default function AnswerItem() {
+  return (
+    <div className="flex gap-3">
+      <input type="checkbox" name="" id="" className="cursor-pointer" />
+      <p className="bg-white min-w-40 max-w-3/4 rounded-md border border-gray-100 p-4 cursor-pointer">
+        선택지 1 safas adsga
+      </p>
+    </div>
+  )
+}

--- a/widgets/quiz-container/ui/QuizItem.tsx
+++ b/widgets/quiz-container/ui/QuizItem.tsx
@@ -1,0 +1,7 @@
+export default function QuizItem() {
+  return (
+    <div className="bg-white min-w-48 max-w-3/4 rounded-md border border-gray-100 p-5 text-center font-bold text-lg">
+      इकट्ठा करना इकट्ठा करना
+    </div>
+  )
+}

--- a/widgets/word-list-container/index.ts
+++ b/widgets/word-list-container/index.ts
@@ -1,0 +1,1 @@
+export { default as WordItem } from './ui/WordItem'

--- a/widgets/word-list-container/ui/WordItem.tsx
+++ b/widgets/word-list-container/ui/WordItem.tsx
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge'
 
 export default function WordItem() {
   return (
-    <div className="bg-white p-4 border-b border-gray-100 flex gap-2 items-start">
+    <div className="bg-white p-4 border-b border-gray-200 flex gap-2 items-start">
       <span
         className={twMerge(
           'bg-[#A5D993] rounded-md w-5 h-5 text-center text-sm mt-1 text-gray-600',

--- a/widgets/word-list-container/ui/WordItem.tsx
+++ b/widgets/word-list-container/ui/WordItem.tsx
@@ -1,0 +1,25 @@
+import { Speech } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+
+export default function WordItem() {
+  return (
+    <div className="bg-white p-4 border-b border-gray-100 flex gap-2 items-start">
+      <span
+        className={twMerge(
+          'bg-[#A5D993] rounded-md w-5 h-5 text-center text-sm mt-1 text-gray-600',
+        )}
+      >
+        vi
+      </span>
+      <div className="flex-1 gap-2 items-start">
+        <div className="flex gap-2 items-center">
+          <h3 className="font-bold ">힌디어</h3>
+          <p className="flex-1 text-gray-400 text-xs">발음</p>
+        </div>
+
+        <h3 className="text-sm">한국어</h3>
+      </div>
+      <Speech className="w-4 text-gray-400" />
+    </div>
+  )
+}


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- lucid react 아이콘 설치 
- 각 페이지별로 필요한 UI 컴포넌트 분리 및 페이지 단에서 조합
- 각 페이지 메타태그 추가 

## 관련 이슈
- close #8 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
**Lucide React 아이콘을 설치한 이유**
- SVG 기반으로 커스터마이징이 용이하고, 프로젝트 전반에서 일관된 아이콘 스타일을 유지할 수 있기 때문

**페이지 전환 시 헤더 UI 변경 요구사항**
- 리스트 페이지: 로고 표시
- 상세 페이지: 뒤로가기 버튼 표시
- 아이템 클릭 → 상세 페이지 이동 시 자연스럽게 헤더가 변경되어야 하는 구조였음

**고민했던 점**
- 전역 상태로 헤더의 상태(뒤로가기/로고)를 관리할지
- 각 페이지마다 layout.tsx를 별도로 만들어 관리할지

**해결**
- 전역 상태로 관리하면 불필요한 사이드 이펙트 발생 가능성이 있음
- 동적 라우팅마다 layout.tsx를 따로 만들면 파일 수가 증가하여 유지보수가 비효율적이라고 판단
=> **Header 컴포넌트 내부에서 searchParams의 id 존재 여부를 확인**
- id가 있으면 → 뒤로가기, 없으면 → 로고를 표시하도록 조건부 렌더링함



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Day, Quiz, and Theme pages with conditional detail views.
  * Introduced CategoryButton navigation and new WordItem, QuizItem, and AnswerItem components.

* **UI Updates**
  * Replaced logo with a new Header including a back button.
  * Navigation bar updated for route-based transitions and uppercase labels.
  * Word cards show Korean/Hindi text, pronunciation, badge, and audio icon.

* **Dependencies**
  * Added an icon library for improved UI icons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->