### PR TITLE
feat<Quiz>: 퀴즈 프로그래스바 추가

### DIFF
--- a/features/quiz/index.ts
+++ b/features/quiz/index.ts
@@ -1,3 +1,4 @@
 export { useQuiz } from './model/useQuiz'
 export { default as AnswerItem } from './ui/AnswerItem'
 export { default as QuizItem } from './ui/QuizItem'
+export { default as ProgressBar } from './ui/ProgressBar'

--- a/features/quiz/model/useQuiz.ts
+++ b/features/quiz/model/useQuiz.ts
@@ -54,6 +54,12 @@ export function useQuiz({ data }: Props) {
     }
   }, 500)
 
+  const resetQuiz = () => {
+    setCurrentIndex(0)
+    setSelectedOption(null)
+    setWrongList([])
+  }
+
   return {
     quizList,
     shuffled,
@@ -61,6 +67,7 @@ export function useQuiz({ data }: Props) {
     selectedOption,
     currentIndex,
     isFinished,
+    resetQuiz,
     handleQuiz,
   }
 }

--- a/features/quiz/ui/ProgressBar.tsx
+++ b/features/quiz/ui/ProgressBar.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  value: number
+}
+export default function ProgressBar({ value }: Props) {
+  return (
+    <div className="w-full h-3 bg-gray-50 rounded ">
+      <div
+        className="h-full bg-accent rounded transition-all duration-500"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  )
+}

--- a/widgets/quiz-container/ui/QuizContainer.tsx
+++ b/widgets/quiz-container/ui/QuizContainer.tsx
@@ -1,51 +1,66 @@
 'use client'
 import { Word } from '@/entities/word'
-import { AnswerItem, useQuiz, QuizItem } from '@/features/quiz'
+import { AnswerItem, useQuiz, QuizItem, ProgressBar } from '@/features/quiz'
 import { WordItem } from '@/features/word-list'
+import { MoveToButton } from '@/shared/ui'
+import { BookOpenCheck } from 'lucide-react'
 
 interface Props {
   data: Word[]
 }
 export default function QuizContainer({ data }: Props) {
-  const { quizList, shuffled, wrongList, selectedOption, currentIndex, isFinished, handleQuiz } =
-    useQuiz({ data })
-
+  const {
+    quizList,
+    shuffled,
+    wrongList,
+    selectedOption,
+    currentIndex,
+    isFinished,
+    resetQuiz,
+    handleQuiz,
+  } = useQuiz({ data })
   return (
     <>
-      <div className="flex flex-col py-5 gap-5 items-center bg-secondary rounded-b-md rounded-r-md min-h-[85vh] w-full">
-        <>
-          {isFinished ? (
-            <>
-              <p className="text-white text-lg ">
-                {wrongList.length}/{quizList.length}
+      <div className="flex flex-col py-5 gap-5 items-center bg-secondary rounded-b-md rounded-r-md min-h-[calc(100dvh-140px)] w-full">
+        {isFinished ? (
+          <>
+            <div className="px-4 w-full">
+              <p className="text-white text-base p-2">
+                {quizList.length - wrongList.length} / {quizList.length}
               </p>
-              <div className="flex flex-col gap-3 min-w-3/5">
-                {wrongList.map((item) => (
-                  <WordItem key={item} word={shuffled[item]} isHidden={false} />
-                ))}
-              </div>
-            </>
-          ) : (
-            <>
-              <p className="text-white text-lg mb-10">
+              <ProgressBar value={((quizList.length - wrongList.length) / quizList.length) * 100} />
+            </div>
+
+            <MoveToButton label="다시 퀴즈" onClick={resetQuiz} icon={BookOpenCheck} />
+            <div className="flex flex-1 flex-col gap-3 min-w-3/5 w-full px-3">
+              {wrongList.map((item) => (
+                <WordItem key={item} word={shuffled[item]} isHidden={false} />
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="px-4  w-full">
+              <p className="text-white text-base">
                 {currentIndex + 1}/{quizList.length}
               </p>
-              <div className="flex flex-col gap-8">
-                <QuizItem question={quizList[currentIndex].question} />
-                <div className="flex flex-col gap-6 items-center">
-                  {quizList[currentIndex].chooseList.map((i, index) => (
-                    <AnswerItem
-                      option={i.option}
-                      onChoose={handleQuiz}
-                      key={index}
-                      isSelected={selectedOption === i.option}
-                    />
-                  ))}
-                </div>
+              <ProgressBar value={(currentIndex / quizList.length) * 100} />
+            </div>
+            <div className="flex flex-1 flex-col items-center justify-center gap-10">
+              <QuizItem question={quizList[currentIndex].question} />
+              <div className="flex flex-col gap-6 items-center">
+                {quizList[currentIndex].chooseList.map((i, index) => (
+                  <AnswerItem
+                    option={i.option}
+                    onChoose={handleQuiz}
+                    key={index}
+                    isSelected={selectedOption === i.option}
+                  />
+                ))}
               </div>
-            </>
-          )}
-        </>
+            </div>
+          </>
+        )}
       </div>
     </>
   )

--- a/widgets/theme-category-list/ui/ThemeCategoryList.tsx
+++ b/widgets/theme-category-list/ui/ThemeCategoryList.tsx
@@ -13,7 +13,7 @@ function ThemeCategoryList({ data }: Props) {
 
   return (
     <div className="flex flex-col ">
-      <div className="sticky top-18 z-40 bg-secondary h-16 flex items-center">
+      <div className="sticky top-18 z-40 y py-3 flex items-center">
         <SearchBar value={keyword} onChange={onInputChange} />
       </div>
 


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
### Feat
- 퀴즈 결과 화면에 다시 퀴즈로 돌아가는 버튼 및 함수 추가 
- 퀴즈 중 현재 현황을 알 수 있는 프로그래스 바 추가 

## 관련 이슈
- close #24 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
### 퀴즈 결과 화면에 다시 퀴즈로 돌아가는 버튼 및 함수 추가 
**resetQuiz함수 추가**
- 현재 퀴즈 상태, 선택한 퀴즈 옵션 상태, 오답리스트를 초기화
- 퀴즈 결과 화면에서 '다시 퀴즈'를 클릭하면 퀴즈 시작 페이지로 이동 
- 틀린 퀴즈만 보는게 아니라 전체 퀴즈를 다시 보는 이유 : 오답만 복습하는 방식보다 전체 문제를 반복적으로 학습하는 UX가 더 적절하다고 판딘

**ProgressBar 컴포넌트 추가** 
-  별도 UI 라이브러리 없이 Tailwind CSS만 사용해 구현
- 퀴즈 진행 화면과 결과 화면 모두에서 동일한 ProgressBar 컴포넌트 재사용
- 라이브러리를 사용하지 않은 이유 : 프로그래스 바는 단순한 진행 상태 표시 UI라 라이브러리 도입에 따른 의존성 증가보다 Tailwind 기반의 경량 구현이 더 적합하다고 판단

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a progress bar to visualize quiz completion during active quizzes
  * Added ability to restart a quiz after finishing
  * Enhanced quiz completion screen to display score and show incorrectly answered items

* **Style**
  * Updated styling for the theme navigation header

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->