### PR TITLE
refactor<CssStyle>: 데이, 테마 페이지 단어 css 고정 및 단어 컴포넌트화

### DIFF
--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -17,7 +17,7 @@ export default async function ThemePage({ searchParams }: { searchParams: { id?:
   return (
     <div
       className={twMerge(
-        'flex flex-col gap-2 p-3 bg-secondary rounded-b-md rounded-r-md',
+        'flex flex-col gap-2 p-3 bg-secondary rounded-b-md rounded-r-md ',
         isParams && 'bg-white border border-gray-200',
       )}
     >

--- a/features/go-to-quiz/index.ts
+++ b/features/go-to-quiz/index.ts
@@ -1,0 +1,3 @@
+export { useGotoQuiz } from './model/useGotoQuiz'
+
+export { default as GotoQuizButton } from './ui/GotoQuizButton'

--- a/features/go-to-quiz/model/useGotoQuiz.ts
+++ b/features/go-to-quiz/model/useGotoQuiz.ts
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  params: string
+}
+export function useGotoQuiz({ params }: Props) {
+  const router = useRouter()
+  const gotoQuiz = () => {
+    router.push(`/quiz?label=day&id=${params}`)
+  }
+  return gotoQuiz
+}

--- a/features/go-to-quiz/ui/GotoQuizButton.tsx
+++ b/features/go-to-quiz/ui/GotoQuizButton.tsx
@@ -1,0 +1,10 @@
+import { MoveToButton } from '@/shared/ui'
+import { BookOpenCheck } from 'lucide-react'
+
+interface Props {
+  gotoQuiz: () => void
+}
+
+export default function GotoQuizButton({ gotoQuiz }: Props) {
+  return <MoveToButton label="퀴즈" onClick={gotoQuiz} icon={BookOpenCheck} />
+}

--- a/features/hide-word/index.ts
+++ b/features/hide-word/index.ts
@@ -1,0 +1,3 @@
+export { useHideWordsMeaning } from './model/useHideWordsMeaning'
+
+export { default as HideWordButton } from './ui/HideWordButton'

--- a/features/hide-word/model/useHideWordsMeaning.ts
+++ b/features/hide-word/model/useHideWordsMeaning.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react'
+
+export function useHideWordsMeaning() {
+  const [isHidden, setIsHidden] = useState(false)
+
+  const handleHideMeaning = () => {
+    setIsHidden(!isHidden)
+  }
+
+  return {
+    isHidden,
+    setIsHidden,
+    handleHideMeaning,
+  }
+}

--- a/features/hide-word/ui/HideWordButton.tsx
+++ b/features/hide-word/ui/HideWordButton.tsx
@@ -1,0 +1,17 @@
+import { MoveToButton } from '@/shared/ui'
+import { Eye, EyeClosed } from 'lucide-react'
+
+interface Props {
+  isHidden: boolean
+  handleHideMeaning: () => void
+}
+
+export default function HideWordButton({ isHidden, handleHideMeaning }: Props) {
+  return (
+    <MoveToButton
+      label={isHidden ? '뜻 보기' : '뜻 가리기'}
+      icon={isHidden ? Eye : EyeClosed}
+      onClick={handleHideMeaning}
+    />
+  )
+}

--- a/features/switch-opposite-word/index.ts
+++ b/features/switch-opposite-word/index.ts
@@ -1,0 +1,3 @@
+export { useSwitchOpposite } from './model/useSwitchOpposite'
+
+export { default as OppositeWordButton } from './ui/OppositeWordButton'

--- a/features/switch-opposite-word/model/useSwitchOpposite.ts
+++ b/features/switch-opposite-word/model/useSwitchOpposite.ts
@@ -1,0 +1,34 @@
+import { Word } from '@/entities/word'
+import { supabase } from '@/shared/api/supabase/client'
+import { useToast } from '@/shared/utils'
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
+
+interface Props {
+  params: string
+}
+
+export function useSwitchOpposite({ params }: Props) {
+  const router = useRouter()
+  const [wordList, setData] = useState<Word[]>()
+  const [opposition, setOpposition] = useState<string>()
+  const { error } = useToast()
+
+  const getWordList = useCallback(async () => {
+    const { data } = await supabase.from('theme_list').select('*').eq('theme', params)
+    if (!data) return error('테마 단어 데이터가 없습니다.')
+    setData(data[0].words)
+    setOpposition(data[0].opposition)
+  }, [params, error])
+
+  const gotoCheckOpposition = () => {
+    if (!opposition) return error('반의어 데이터가 없습니다.')
+    router.push(`/theme?id=${opposition}`)
+  }
+
+  return {
+    wordList,
+    getWordList,
+    gotoCheckOpposition,
+  }
+}

--- a/features/switch-opposite-word/ui/OppositeWordButton.tsx
+++ b/features/switch-opposite-word/ui/OppositeWordButton.tsx
@@ -1,0 +1,10 @@
+import { MoveToButton } from '@/shared/ui'
+import { Check } from 'lucide-react'
+
+interface Props {
+  gotoCheckOpposition: () => void
+}
+
+export default function OppositeWordButton({ gotoCheckOpposition }: Props) {
+  return <MoveToButton label="반의어 확인" icon={Check} onClick={gotoCheckOpposition} />
+}

--- a/widgets/day-word-list/ui/DayWordList.tsx
+++ b/widgets/day-word-list/ui/DayWordList.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { Word } from '@/entities/word'
+import { HideWordButton, useHideWordsMeaning } from '@/features/hide-word'
 import { WordItem } from '@/features/word-list'
 import { MoveToButton } from '@/shared/ui'
-import { BookOpenCheck, EyeClosed, Eye } from 'lucide-react'
+import { BookOpenCheck } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+
 interface Props {
   params: string
   wordList: Word[]
@@ -13,23 +14,16 @@ interface Props {
 
 export default function DayList({ params, wordList }: Props) {
   const router = useRouter()
-  const [isHidden, setIsHidden] = useState(false)
+  const { isHidden, handleHideMeaning } = useHideWordsMeaning()
 
   const gotoQuiz = () => {
     router.push(`/quiz?label=day&id=${params}`)
-  }
-  const handleHideMeaning = () => {
-    setIsHidden(!isHidden)
   }
 
   return (
     <>
       <div className="flex justify-between">
-        <MoveToButton
-          label={isHidden ? '뜻 보기' : '뜻 가리기'}
-          icon={isHidden ? Eye : EyeClosed}
-          onClick={handleHideMeaning}
-        />
+        <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <MoveToButton label="퀴즈" onClick={gotoQuiz} icon={BookOpenCheck} />
       </div>
       {wordList &&

--- a/widgets/day-word-list/ui/DayWordList.tsx
+++ b/widgets/day-word-list/ui/DayWordList.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import { Word } from '@/entities/word'
+import { GotoQuizButton, useGotoQuiz } from '@/features/go-to-quiz'
 import { HideWordButton, useHideWordsMeaning } from '@/features/hide-word'
 import { WordItem } from '@/features/word-list'
-import { MoveToButton } from '@/shared/ui'
-import { BookOpenCheck } from 'lucide-react'
-import { useRouter } from 'next/navigation'
 
 interface Props {
   params: string
@@ -13,18 +11,14 @@ interface Props {
 }
 
 export default function DayList({ params, wordList }: Props) {
-  const router = useRouter()
   const { isHidden, handleHideMeaning } = useHideWordsMeaning()
-
-  const gotoQuiz = () => {
-    router.push(`/quiz?label=day&id=${params}`)
-  }
+  const gotoQuiz = useGotoQuiz({ params })
 
   return (
     <>
       <div className="flex justify-between">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
-        <MoveToButton label="퀴즈" onClick={gotoQuiz} icon={BookOpenCheck} />
+        <GotoQuizButton gotoQuiz={gotoQuiz} />
       </div>
       {wordList &&
         wordList.map((word) => <WordItem key={word.id} word={word} isHidden={isHidden} />)}

--- a/widgets/day-word-list/ui/DayWordList.tsx
+++ b/widgets/day-word-list/ui/DayWordList.tsx
@@ -15,13 +15,13 @@ export default function DayList({ params, wordList }: Props) {
   const gotoQuiz = useGotoQuiz({ params })
 
   return (
-    <>
-      <div className="flex justify-between">
+    <div className="flex flex-col ">
+      <div className="sticky top-18 z-40 y py-2 flex  justify-between bg-white">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <GotoQuizButton gotoQuiz={gotoQuiz} />
       </div>
       {wordList &&
         wordList.map((word) => <WordItem key={word.id} word={word} isHidden={isHidden} />)}
-    </>
+    </div>
   )
 }

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -3,11 +3,12 @@
 import { Word } from '@/entities/word'
 import { supabase } from '@/shared/api/supabase/client'
 import { useCallback, useEffect, useState } from 'react'
-import { BookOpenCheck, Check, EyeClosed, Eye } from 'lucide-react'
+import { BookOpenCheck, Check } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { MoveToButton } from '@/shared/ui'
 import { WordItem } from '@/features/word-list'
 import { useToast } from '@/shared/utils'
+import { HideWordButton, useHideWordsMeaning } from '@/features/hide-word'
 
 interface Props {
   params: string
@@ -16,7 +17,8 @@ function ThemeWordList({ params }: Props) {
   const router = useRouter()
   const [wordList, setData] = useState<Word[]>()
   const [opposition, setOpposition] = useState<string>()
-  const [isHidden, setIsHidden] = useState(false)
+  const { isHidden, setIsHidden, handleHideMeaning } = useHideWordsMeaning()
+
   const { error } = useToast()
 
   const getWordList = useCallback(async () => {
@@ -34,9 +36,6 @@ function ThemeWordList({ params }: Props) {
   const gotoQuiz = () => {
     router.push(`/quiz?label=theme&id=${params}`)
   }
-  const handleHideMeaning = () => {
-    setIsHidden(!isHidden)
-  }
 
   useEffect(() => {
     getWordList()
@@ -46,11 +45,7 @@ function ThemeWordList({ params }: Props) {
   return (
     <>
       <div className="flex justify-between">
-        <MoveToButton
-          label={isHidden ? '뜻 보기' : '뜻 가리기'}
-          icon={isHidden ? Eye : EyeClosed}
-          onClick={handleHideMeaning}
-        />
+        <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <MoveToButton label="반의어 확인" icon={Check} onClick={gotoCheckOpposition} />
         {wordList && wordList.length > 3 && (
           <MoveToButton label="퀴즈" onClick={gotoQuiz} icon={BookOpenCheck} />

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -1,38 +1,20 @@
 'use client'
 
-import { Word } from '@/entities/word'
-import { supabase } from '@/shared/api/supabase/client'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { Check } from 'lucide-react'
-import { useRouter } from 'next/navigation'
 import { MoveToButton } from '@/shared/ui'
 import { WordItem } from '@/features/word-list'
-import { useToast } from '@/shared/utils'
 import { HideWordButton, useHideWordsMeaning } from '@/features/hide-word'
 import { GotoQuizButton, useGotoQuiz } from '@/features/go-to-quiz'
+import { useSwitchOpposite } from '@/features/switch-opposite-word'
 
 interface Props {
   params: string
 }
 function ThemeWordList({ params }: Props) {
-  const router = useRouter()
-  const [wordList, setData] = useState<Word[]>()
-  const [opposition, setOpposition] = useState<string>()
   const { isHidden, setIsHidden, handleHideMeaning } = useHideWordsMeaning()
   const gotoQuiz = useGotoQuiz({ params })
-  const { error } = useToast()
-
-  const getWordList = useCallback(async () => {
-    const { data } = await supabase.from('theme_list').select('*').eq('theme', params)
-    if (!data) return error('테마 단어 데이터가 없습니다.')
-    setData(data[0].words)
-    setOpposition(data[0].opposition)
-  }, [params, error])
-
-  const gotoCheckOpposition = () => {
-    if (!opposition) return error('반의어 데이터가 없습니다.')
-    router.push(`/theme?id=${opposition}`)
-  }
+  const { wordList, getWordList, gotoCheckOpposition } = useSwitchOpposite({ params })
 
   useEffect(() => {
     getWordList()
@@ -40,15 +22,15 @@ function ThemeWordList({ params }: Props) {
   }, [params])
 
   return (
-    <>
-      <div className="flex justify-between">
+    <div className="min-h-[calc(100dvh-160px)]">
+      <div className="flex justify-between ">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <MoveToButton label="반의어 확인" icon={Check} onClick={gotoCheckOpposition} />
         {wordList && wordList.length > 3 && <GotoQuizButton gotoQuiz={gotoQuiz} />}
       </div>
       {wordList &&
         wordList.map((word) => <WordItem key={word.id} word={word} isHidden={isHidden} />)}
-    </>
+    </div>
   )
 }
 export default ThemeWordList

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -12,9 +12,9 @@ interface Props {
   params: string
 }
 function ThemeWordList({ params }: Props) {
+  const { wordList, getWordList, gotoCheckOpposition } = useSwitchOpposite({ params })
   const { isHidden, setIsHidden, handleHideMeaning } = useHideWordsMeaning()
   const gotoQuiz = useGotoQuiz({ params })
-  const { wordList, getWordList, gotoCheckOpposition } = useSwitchOpposite({ params })
 
   useEffect(() => {
     getWordList()
@@ -22,8 +22,8 @@ function ThemeWordList({ params }: Props) {
   }, [params])
 
   return (
-    <div className="min-h-[calc(100dvh-160px)]">
-      <div className="flex justify-between ">
+    <div className="flex flex-col min-h-[calc(100dvh-160px)]">
+      <div className="sticky top-18 z-40 y py-2 flex  justify-between bg-white">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <MoveToButton label="반의어 확인" icon={Check} onClick={gotoCheckOpposition} />
         {wordList && wordList.length > 3 && <GotoQuizButton gotoQuiz={gotoQuiz} />}

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -3,12 +3,13 @@
 import { Word } from '@/entities/word'
 import { supabase } from '@/shared/api/supabase/client'
 import { useCallback, useEffect, useState } from 'react'
-import { BookOpenCheck, Check } from 'lucide-react'
+import { Check } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { MoveToButton } from '@/shared/ui'
 import { WordItem } from '@/features/word-list'
 import { useToast } from '@/shared/utils'
 import { HideWordButton, useHideWordsMeaning } from '@/features/hide-word'
+import { GotoQuizButton, useGotoQuiz } from '@/features/go-to-quiz'
 
 interface Props {
   params: string
@@ -18,7 +19,7 @@ function ThemeWordList({ params }: Props) {
   const [wordList, setData] = useState<Word[]>()
   const [opposition, setOpposition] = useState<string>()
   const { isHidden, setIsHidden, handleHideMeaning } = useHideWordsMeaning()
-
+  const gotoQuiz = useGotoQuiz({ params })
   const { error } = useToast()
 
   const getWordList = useCallback(async () => {
@@ -33,10 +34,6 @@ function ThemeWordList({ params }: Props) {
     router.push(`/theme?id=${opposition}`)
   }
 
-  const gotoQuiz = () => {
-    router.push(`/quiz?label=theme&id=${params}`)
-  }
-
   useEffect(() => {
     getWordList()
     setIsHidden(false)
@@ -47,9 +44,7 @@ function ThemeWordList({ params }: Props) {
       <div className="flex justify-between">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <MoveToButton label="반의어 확인" icon={Check} onClick={gotoCheckOpposition} />
-        {wordList && wordList.length > 3 && (
-          <MoveToButton label="퀴즈" onClick={gotoQuiz} icon={BookOpenCheck} />
-        )}
+        {wordList && wordList.length > 3 && <GotoQuizButton gotoQuiz={gotoQuiz} />}
       </div>
       {wordList &&
         wordList.map((word) => <WordItem key={word.id} word={word} isHidden={isHidden} />)}


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
### Refactor
- 뜻 가리는 버튼 컴포넌트로 변경-> HideWordButton
- 퀴즈 페이지로 이동하는 버튼 컴포넌트로 변경 -> GotoQuizButton
- 반의어 확인 버튼 컴포넌트로 변경 -> GotoQuizButton
- 데이, 테마 페이지 단어 css 고정  -> 스크롤해도 위치 고정됨 
## 관련 이슈
- close #26 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
**버튼 컴포넌트를 분리하게 된 이유** 
- DayPage와 ThemePage에서 동일한 버튼 UI와 로직을 중복 사용하고 있음 + 기존에는 widgets 레이어 내에서 UI와 로직의 경계가 모호했음   -> 재사용성 및 유지보수성 향상을 위해 버튼 컴포넌트를 features로 파일 분리

**Day / Theme 페이지 단어리스트의 버튼 위치 고정**
- 단어 데이터가 많아질 경우 스크롤이 발생 -> 상단 네비게이션은 유지되지만 주요 버튼(뜻 가리기, 퀴즈, 반의어 확인)이 화면에서 사라지는 문제 발생 
=> 학습 중 하단 단어를 보고 있을 때도 기능들을 사용할 수 있도록 버튼 영역을 고정 UI로 변경하여 사용자 경험을 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Users can now toggle word meanings visibility with a dedicated button
  - Added quick navigation to quiz from word lists
  - New feature to check opposite words within theme lists
  - Enhanced word list interface with streamlined action buttons for improved usability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->