### PR TITLE
fix<Common>: supabase 빌드 에러 - client.ts에 'use client' 추가

### DIFF
--- a/shared/api/supabase/client.ts
+++ b/shared/api/supabase/client.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createBrowserClient } from '@supabase/ssr'
 
 export const supabase = createBrowserClient(


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- supabase 빌드 에러 - client.ts에 'use client' 추가

## 관련 이슈
- close #32 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
- client.ts + 사용하는 컴포넌트 둘 다 'use client' 필요