### PR TITLE
fix<Quiz>: 테마 페이지에서 퀴즈페이지로 이동 안되는 에러 

### DIFF
--- a/features/go-to-quiz/model/useGotoQuiz.ts
+++ b/features/go-to-quiz/model/useGotoQuiz.ts
@@ -2,11 +2,12 @@ import { useRouter } from 'next/navigation'
 
 interface Props {
   params: string
+  label: string
 }
-export function useGotoQuiz({ params }: Props) {
+export function useGotoQuiz({ params, label }: Props) {
   const router = useRouter()
   const gotoQuiz = () => {
-    router.push(`/quiz?label=day&id=${params}`)
+    router.push(`/quiz?label=${label}&id=${params}`)
   }
   return gotoQuiz
 }

--- a/widgets/day-word-list/ui/DayWordList.tsx
+++ b/widgets/day-word-list/ui/DayWordList.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export default function DayList({ params, wordList }: Props) {
   const { isHidden, handleHideMeaning } = useHideWordsMeaning()
-  const gotoQuiz = useGotoQuiz({ params })
+  const gotoQuiz = useGotoQuiz({ params, label: 'day' })
 
   return (
     <div className="flex flex-col ">

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -14,7 +14,7 @@ interface Props {
 function ThemeWordList({ params }: Props) {
   const { wordList, getWordList, gotoCheckOpposition } = useSwitchOpposite({ params })
   const { isHidden, setIsHidden, handleHideMeaning } = useHideWordsMeaning()
-  const gotoQuiz = useGotoQuiz({ params })
+  const gotoQuiz = useGotoQuiz({ params, label: 'theme' })
 
   useEffect(() => {
     getWordList()


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- 테마 페이지에서 퀴즈페이지로 이동 안되는 에러 -> useGotoQuiz에서 라우팅 주소 수정

## 관련 이슈
- close #38 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
원인
- 이전에 로직과 ui를 분리하면서 라우팅을 관리하였는데, 이 때 라우팅 주소를 데이페이지에서 사용했던 주소 그대로 사용함. 
문제
- 데이페이지에서 퀴즈 페이지로 이동이 잘되는데, 테마 페이지에서는 퀴즈페이지로 이동하지 못함 
- > 사용자들의 혼란을 야기함 
해결 
-> Props로 label을 받아서 페이지를 이동함 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced quiz navigation to dynamically route based on content category, enabling seamless transitions between different word list types and quiz sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->