### PR TITLE
fix<Word>: 단어 음성 안들릴 때 예외처리 및  hover 상태만 존재하던 인터랙션 UI에 active 스타일을 추가

### DIFF
--- a/features/category/ui/CategoryButton.tsx
+++ b/features/category/ui/CategoryButton.tsx
@@ -23,7 +23,8 @@ export default function CategoryButton({ label, id }: Props) {
 
   return (
     <button
-      className="flex w-full bg-white rounded-md p-2 justify-between items-center border border-gray-100 text-base cursor-pointer hover:bg-gray-300 hover:translate-y-0.5"
+      className="flex w-full bg-white rounded-md p-2 justify-between items-center border border-gray-100 text-base cursor-pointer 
+      hover:bg-gray-300 hover:translate-y-0.5 active:bg-gray-300 active:translate-y-0.5 "
       onClick={goToDetailPage}
     >
       {label}

--- a/features/quiz/ui/AnswerItem.tsx
+++ b/features/quiz/ui/AnswerItem.tsx
@@ -11,7 +11,7 @@ export default function AnswerItem({ option, isSelected, onChoose }: Props) {
     <button className="flex gap-3 cursor-pointer" onClick={() => onChoose(option)}>
       <p
         className={twMerge(
-          'bg-white min-w-40 max-w-3/4 rounded-md border border-gray-100 p-4 hover:bg-gray-300 hover:translate-0.5',
+          'bg-white min-w-40 max-w-3/4 rounded-md border border-gray-100 p-4 hover:bg-gray-300 hover:translate-0.5 active:bg-gray-300 active:translate-0.5',
           isSelected && 'bg-accent border-accent',
         )}
       >

--- a/features/word-list/model/useWord.ts
+++ b/features/word-list/model/useWord.ts
@@ -1,4 +1,7 @@
+import { useToast } from '@/shared/utils'
+
 export default function useWord() {
+  const { warn } = useToast()
   const getBackgroundColors = (position: string) => {
     if (position === 'noun_m') return 'bg-[#ABD8F5]'
     else if (position === 'noun_f') return 'bg-[#FF9595]'
@@ -18,9 +21,13 @@ export default function useWord() {
     else return '정보없음'
   }
   const onSpeak = (word: string) => {
-    const utter = new SpeechSynthesisUtterance(word)
-    utter.lang = 'hi-IN'
-    speechSynthesis.speak(utter)
+    try {
+      const utter = new SpeechSynthesisUtterance(word)
+      utter.lang = 'hi-IN'
+      speechSynthesis.speak(utter)
+    } catch {
+      warn('힌디어 발음은 기기 설정에 따라 지원되지 않을 수 있습니다!')
+    }
   }
   return {
     getBackgroundColors,

--- a/features/word-list/ui/WordItem.tsx
+++ b/features/word-list/ui/WordItem.tsx
@@ -40,8 +40,11 @@ export default function WordItem({ word, isHidden, isLast }: Props) {
           <h3 className="text-base">{word.한국어}</h3>
         )}
       </div>
-      <button onClick={() => onSpeak(word.힌디어)}>
-        <Speech className="w-4 text-gray-400 cursor-pointer hover:translate-y-0.5" />
+      <button
+        onClick={() => onSpeak(word.힌디어)}
+        className="cursor-pointer hover:translate-y-0.5 p-2 rounded hover:bg-gray-200 active:bg-gray-200 "
+      >
+        <Speech className="w-4 text-gray-400" />
       </button>
     </div>
   )

--- a/shared/ui/EmptyData.tsx
+++ b/shared/ui/EmptyData.tsx
@@ -9,8 +9,9 @@ export default function EmptyData({ text, mode }: Props) {
   return (
     <div
       className={twMerge(
-        'flex flex-col gap-3 items-center justify-center text-gray-900 min-h-[calc(100dvh-140px)] bg-white rounded-b-md rounded-r-md border border-gray-200',
-        mode === 'light' && 'text-white bg-secondary  border-secondary min-h-[calc(100dvh-220px)]',
+        'flex flex-col gap-3 items-center justify-center text-gray-900 min-h-[calc(100dvh-140px)] bg-white rounded-b-md rounded-r-md ',
+        mode === 'light' &&
+          'text-white bg-secondary border border-secondary min-h-[calc(100dvh-220px)]',
       )}
     >
       <CircleAlert className={twMerge('text-gray-600 min-x-5', mode === 'light' && 'text-white')} />

--- a/shared/ui/GotoTopButton.tsx
+++ b/shared/ui/GotoTopButton.tsx
@@ -10,7 +10,7 @@ function GotoTopButton() {
   return (
     <button
       onClick={handleClick}
-      className="fixed bottom-6 right-6 rounded-full bg-gray-300 p-2 text-center shadow-2xl cursor-pointer hover:bg-accent"
+      className="fixed bottom-6 right-6 rounded-full bg-gray-300 p-2 text-center shadow-2xl cursor-pointer hover:bg-accent active:bg-accent"
     >
       <ChevronUp />
     </button>

--- a/shared/ui/MoveToButton.tsx
+++ b/shared/ui/MoveToButton.tsx
@@ -11,7 +11,7 @@ interface Props {
 export default function MoveToButton({ label, icon: Icon, onClick }: Props) {
   return (
     <button
-      className="bg-white flex gap-1 items-center px-2 py-1 rounded border border-gray-200 text-gray-500 cursor-pointer hover:bg-gray-100"
+      className="bg-white flex gap-1 items-center px-2 py-1 rounded border border-gray-200 text-gray-500 cursor-pointer hover:bg-gray-100 active:bg-gray-100"
       onClick={onClick}
     >
       <Icon className="w-4" /> <p className="text-sm ">{label}</p>

--- a/shared/ui/NavigationButton.tsx
+++ b/shared/ui/NavigationButton.tsx
@@ -25,7 +25,7 @@ export default function NavigationButton({ label, isActive }: Props) {
       <Link href={label === 'DAY' ? '/' : 'theme'} prefetch>
         <button
           className={twMerge(
-            'bg-gray-200 rounded-t-md px-4 py-1 text-base font-bold hover:bg-gray-400 hover:cursor-pointer',
+            'bg-gray-200 rounded-t-md px-4 py-1 text-base font-bold hover:bg-gray-400 hover:cursor-pointer active:bg-gray-400 active:cursor-pointer',
             isActive && 'text-white bg-primary ',
           )}
         >

--- a/shared/ui/ToastItem.tsx
+++ b/shared/ui/ToastItem.tsx
@@ -27,7 +27,10 @@ export default function ToastItem({ id, message, type }: Props) {
     >
       <span>{message}</span>
 
-      <button onClick={() => removeToast(id)} className="ml-3 opacity-80 hover:opacity-100">
+      <button
+        onClick={() => removeToast(id)}
+        className="ml-3 opacity-80 hover:opacity-100 active:opacity-100"
+      >
         <X size={16} />
       </button>
     </div>


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- 힌디어 단어 음성 재생이 되지 않는 경우에 대한 예외 처리 추가
- hover 상태만 존재하던 인터랙션 UI에 active 스타일을 추가하여 모바일 환경 대응

## 관련 이슈
- close #41 
## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
### 단어 음성 안들릴 때 예외처리 
단어 음성이 안 들리는 이유 : 힌디어(hi-IN) 음성 엔진이 기기에 없음
- SpeechSynthesisUtterance는 브라우저가 아니라 OS에 설치된 TTS 음성 엔진를 씀 -> 사용자의 환경마다 다름 
- utter.lang = 'hi-IN'은 요청일 뿐 보장이 아님 -> 지원 음성이 없으면 그냥 무시됨
-> 따라서, onSpeak 함수에 try-catch 문을 추가하여 힌디어 발음이 없는 경우는 토스트를 통해 사용자에게 지원되지 않음을 안내 

### 모바일 UI 환경 대응 

- 데스크탑 hover 기반 UI가 모바일 환경에서는 피드백이 없던 문제 발생 => 모든 인터랙션 요소에 active 상태를 추가하여 터치 시 시각적 반응 제공
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced visual feedback for button interactions with active state styling across the app
  * Improved empty data display border styling

* **Bug Fixes**
  * Added error handling for speech pronunciation feature with user-friendly warning messages when synthesis fails

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->