### PR TITLE
feat<CssStyle>: 다크 모드 지원

### DIFF
--- a/app/day/page.tsx
+++ b/app/day/page.tsx
@@ -21,7 +21,7 @@ export default async function DayPage({ searchParams }: { searchParams: { id?: s
   }
 
   return (
-    <div className="flex flex-col gap-3 p-3 bg-white rounded-b-md rounded-r-md border border-gray-200">
+    <div className="flex flex-col gap-3 p-3 bg-white rounded-b-md rounded-r-md border border-gray-200 dark:bg-gray-800 dark:border-none">
       <HydrationBoundary state={dehydrate(queryClient)}>
         <DayWordList params={params.id} />
       </HydrationBoundary>

--- a/app/day/page.tsx
+++ b/app/day/page.tsx
@@ -17,7 +17,7 @@ export default async function DayPage({ searchParams }: { searchParams: { id?: s
   })
 
   if (!params.id) {
-    return <EmptyData text={'데이터'} mode="dark" />
+    return <EmptyData text={'데이터'} mode="light" />
   }
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,9 +21,9 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <div className="flex justify-center">
-          <div className="relative max-w-3xl w-full bg-white p-5 min-h-screen">
+          <div className="relative max-w-3xl w-full bg-white p-5 min-h-screen dark:bg-gray-900">
             <ToastContainer />
-            <div className="sticky top-0 bg-white z-50">
+            <div className="sticky top-0 z-50">
               <Suspense fallback={null}>
                 <Header />
                 <NavigationBar />

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -2,13 +2,13 @@ import { Loader } from 'lucide-react'
 
 export default function loading() {
   return (
-    <div className="flex flex-col justify-center items-center min-h-[calc(100dvh-220px)] gap-4 bg-white rounded-b-md rounded-r-md border border-gray-200 ">
+    <div className="flex flex-col justify-center items-center min-h-[calc(100dvh-220px)] gap-4 ">
       <Loader
-        className="text-primary animate-spin spin-5s"
+        className="text-primary animate-spin spin-5s dark:text-gray-50"
         size={40}
         style={{ animationDuration: '3s' }}
       />
-      <p className="text-primary">로딩중</p>
+      <p className="text-primary dark:text-gray-50">로딩중</p>
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default async function DayPage() {
   }
 
   return (
-    <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md">
+    <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md dark:bg-gray-800 dark:border dark:border-gray-500 ">
       {result.data &&
         result.data.map((item) => (
           <CategoryButton label={`day${item.id}`} key={item.id} id={item.id} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default async function DayPage() {
   }
 
   return (
-    <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md dark:bg-gray-800 dark:border dark:border-gray-500 ">
+    <div className="flex flex-col gap-3 p-3 bg-secondary rounded-b-md rounded-r-md dark:bg-gray-800 dark:border dark:border-none">
       {result.data &&
         result.data.map((item) => (
           <CategoryButton label={`day${item.id}`} key={item.id} id={item.id} />

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -28,5 +28,9 @@ export default async function QuizPage({
     }
   }
 
-  return <QuizContainer data={result.data.words} />
+  return (
+    <div className="flex flex-col py-5 gap-5 items-center bg-secondary rounded-b-md rounded-r-md min-h-[calc(100dvh-140px)] w-full dark:bg-gray-700">
+      <QuizContainer data={result.data.words} />
+    </div>
+  )
 }

--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -31,8 +31,8 @@ export default async function ThemePage({ searchParams }: { searchParams: { id?:
   return (
     <div
       className={twMerge(
-        'flex flex-col gap-2 p-3 bg-secondary rounded-b-md rounded-r-md ',
-        isParams && 'bg-white border border-gray-200',
+        'flex flex-col gap-2 p-3 bg-secondary rounded-b-md rounded-r-md dark:bg-gray-800 ',
+        isParams && 'bg-white border border-gray-200 dark:bg-gray-800 dark:border-none',
       )}
     >
       {isParams ? (

--- a/features/category/ui/CategoryButton.tsx
+++ b/features/category/ui/CategoryButton.tsx
@@ -24,7 +24,7 @@ export default function CategoryButton({ label, id }: Props) {
   return (
     <button
       className="flex w-full bg-white rounded-md p-2 justify-between items-center border border-gray-100 text-base cursor-pointer 
-      hover:bg-gray-300 hover:translate-y-0.5 active:bg-gray-300 active:translate-y-0.5 "
+      hover:bg-gray-300 hover:translate-y-0.5 active:bg-gray-300 active:translate-y-0.5 dark:bg-gray-500 dark:border-gray-400 dark:hover:bg-gray-700 dark:active:bg-gray-700"
       onClick={goToDetailPage}
     >
       {label}

--- a/features/quiz/ui/AnswerItem.tsx
+++ b/features/quiz/ui/AnswerItem.tsx
@@ -11,7 +11,7 @@ export default function AnswerItem({ option, isSelected, onChoose }: Props) {
     <button className="flex gap-3 cursor-pointer" onClick={() => onChoose(option)}>
       <p
         className={twMerge(
-          'bg-white min-w-40 max-w-3/4 rounded-md border border-gray-100 p-4 hover:bg-gray-300 hover:translate-0.5 active:bg-gray-300 active:translate-0.5',
+          'bg-white min-w-40 max-w-3/4 rounded-md border border-gray-100 p-4 hover:bg-gray-300 hover:translate-0.5 active:bg-gray-300 active:translate-0.5 dark:hover:bg-gray-500 dark:active:bg-gray-500 dark:bg-gray-800 dark:border dark:border-gray-300 ',
           isSelected && 'bg-accent border-accent',
         )}
       >

--- a/features/quiz/ui/QuizItem.tsx
+++ b/features/quiz/ui/QuizItem.tsx
@@ -3,8 +3,11 @@ interface Props {
 }
 export default function QuizItem({ question }: Props) {
   return (
-    <div className="bg-white min-w-48 max-w-3/4 rounded-md border border-gray-100 p-5 text-center font-bold text-lg">
-      {question}
+    <div
+      className="bg-white min-w-48 max-w-3/4 rounded-md border border-gray-100 p-5 text-center font-bold text-lg
+     dark:bg-gray-800 dark:border-none"
+    >
+      {question}0
     </div>
   )
 }

--- a/features/search/ui/SearchBar.tsx
+++ b/features/search/ui/SearchBar.tsx
@@ -8,7 +8,8 @@ export default function SearchBar({ value, onChange }: Props) {
     <input
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="bg-white w-full p-2 rounded-md border border-gray-300 outline-none focus:border-primary focus:ring-primary focus:ring-2"
+      className="bg-white w-full p-2 rounded-md border border-gray-300 outline-none focus:border-primary focus:ring-primary focus:ring-2 
+      dark:bg-gray-600 dark:focus:border-accent dark:focus:ring-accent "
       type="text"
       placeholder="검색어를 입력해 주세요"
     />

--- a/features/word-list/ui/WordItem.tsx
+++ b/features/word-list/ui/WordItem.tsx
@@ -16,13 +16,13 @@ export default function WordItem({ word, isHidden, isLast }: Props) {
   return (
     <div
       className={twMerge(
-        'bg-white p-4 border-b border-gray-200 flex gap-2 items-start rounded',
+        'p-4 border-b border-gray-200 flex gap-2 items-start rounded dark:rounded-b-none',
         isLast && 'border-none',
       )}
     >
       <span
         className={twMerge(
-          'flex items-center justify-center rounded-md w-5 h-5 text-xs mt-1.5',
+          'flex items-center justify-center rounded-md w-5 h-5 text-xs mt-1.5 text-gray-950',
           getBackgroundColors(word.품사),
         )}
       >
@@ -35,7 +35,7 @@ export default function WordItem({ word, isHidden, isLast }: Props) {
         </div>
 
         {isHidden ? (
-          <div className="bg-black w-20 ">숨김</div>
+          <div className="bg-black w-20 text-black">숨김</div>
         ) : (
           <h3 className="text-base">{word.한국어}</h3>
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "lint-staged": "^16.2.7",
         "lucide-react": "^0.555.0",
         "next": "16.0.10",
-        "next-themes": "^0.4.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "tailwind-merge": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lint-staged": "^16.2.7",
         "lucide-react": "^0.555.0",
         "next": "16.0.10",
+        "next-themes": "^0.4.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "tailwind-merge": "^3.4.0",
@@ -5422,6 +5423,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint-staged": "^16.2.7",
     "lucide-react": "^0.555.0",
     "next": "16.0.10",
+    "next-themes": "^0.4.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "tailwind-merge": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lint-staged": "^16.2.7",
     "lucide-react": "^0.555.0",
     "next": "16.0.10",
-    "next-themes": "^0.4.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "tailwind-merge": "^3.4.0",

--- a/shared/ui/EmptyData.tsx
+++ b/shared/ui/EmptyData.tsx
@@ -9,12 +9,20 @@ export default function EmptyData({ text, mode }: Props) {
   return (
     <div
       className={twMerge(
-        'flex flex-col gap-3 items-center justify-center text-gray-900 min-h-[calc(100dvh-140px)] bg-white rounded-b-md rounded-r-md ',
+        'flex flex-col gap-3 items-center justify-center ',
+        mode === 'dark' &&
+          'text-white bg-secondary min-h-[calc(100dvh-220px)] dark:bg-gray-800 dark:border-none',
         mode === 'light' &&
-          'text-white bg-secondary border border-secondary min-h-[calc(100dvh-220px)]',
+          'text-gray-900 min-h-[calc(100dvh-160px)] bg-white rounded-b-md rounded-r-md dark:bg-gray-800 dark:border-none dark:text-gray-50',
       )}
     >
-      <CircleAlert className={twMerge('text-gray-600 min-x-5', mode === 'light' && 'text-white')} />
+      <CircleAlert
+        className={twMerge(
+          'min-x-5',
+          mode === 'light' && 'text-gray-600  dark:text-white',
+          mode === 'dark' && 'text-white',
+        )}
+      />
       {text}
     </div>
   )

--- a/shared/ui/GotoTopButton.tsx
+++ b/shared/ui/GotoTopButton.tsx
@@ -12,7 +12,7 @@ function GotoTopButton() {
       onClick={handleClick}
       className="fixed bottom-6 right-6 rounded-full bg-gray-300 p-2 text-center shadow-2xl cursor-pointer hover:bg-accent active:bg-accent"
     >
-      <ChevronUp />
+      <ChevronUp className="text-gray-950" />
     </button>
   )
 }

--- a/shared/ui/Header.tsx
+++ b/shared/ui/Header.tsx
@@ -11,18 +11,18 @@ export default function Header() {
 
   return (
     <>
-      <div className="flex gap-1 items-center justify-center mb-2 relative max-w-3xl mx-auto">
+      <div className="flex gap-1 items-center justify-center mb-2 relative max-w-3xl mx-auto bg-white dark:bg-gray-900">
         {isDetailPage && (
           <button
-            className="flex items-center text-gray-800 absolute left-0"
+            className="flex items-center text-gray-800 absolute left-0 dark:text-gray-100"
             onClick={() => router.back()}
           >
-            <ChevronLeft className="w-5" /> <p className="text-sm">뒤로</p>
+            <ChevronLeft className="w-5" /> <p className="text-sm ">뒤로</p>
           </button>
         )}
         <div className="flex gap-1 text-2xl font-bold font-hinko">
           <h1 className="text-accent">HIN</h1>
-          <h1 className="text-primary">KOR</h1>
+          <h1 className="text-primary dark:text-blue-500">KOR</h1>
         </div>
       </div>
     </>

--- a/shared/ui/MoveToButton.tsx
+++ b/shared/ui/MoveToButton.tsx
@@ -11,7 +11,8 @@ interface Props {
 export default function MoveToButton({ label, icon: Icon, onClick }: Props) {
   return (
     <button
-      className="bg-white flex gap-1 items-center px-2 py-1 rounded border border-gray-200 text-gray-500 cursor-pointer hover:bg-gray-100 active:bg-gray-100"
+      className="bg-white flex gap-1 items-center px-2 py-1 rounded border border-gray-200 text-gray-500 cursor-pointer
+      hover:bg-gray-100 active:bg-gray-100 dark:bg-gray-400 dark:hover:bg-gray-300 dark:active:bg-gray-300 dark:text-gray-950"
       onClick={onClick}
     >
       <Icon className="w-4" /> <p className="text-sm ">{label}</p>

--- a/shared/ui/NavigationBar.tsx
+++ b/shared/ui/NavigationBar.tsx
@@ -1,15 +1,22 @@
 'use client'
 
 import NavigationButton from './NavigationButton'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 export default function NavigationBar() {
   const path = usePathname()
+  const params = useSearchParams()
 
   return (
     <div className="flex gap-2">
-      <NavigationButton label={'DAY'} isActive={path.startsWith('/day') || path === '/'} />
-      <NavigationButton label={'THEME'} isActive={path.startsWith('/theme')} />
+      <NavigationButton
+        label={'DAY'}
+        isActive={path.startsWith('/day') || path === '/' || params.get('label') === 'day'}
+      />
+      <NavigationButton
+        label={'THEME'}
+        isActive={path.startsWith('/theme') || params.get('label') === 'theme'}
+      />
     </div>
   )
 }

--- a/shared/ui/NavigationButton.tsx
+++ b/shared/ui/NavigationButton.tsx
@@ -25,8 +25,8 @@ export default function NavigationButton({ label, isActive }: Props) {
       <Link href={label === 'DAY' ? '/' : 'theme'} prefetch>
         <button
           className={twMerge(
-            'bg-gray-200 rounded-t-md px-4 py-1 text-base font-bold hover:bg-gray-400 hover:cursor-pointer active:bg-gray-400 active:cursor-pointer',
-            isActive && 'text-white bg-primary ',
+            'bg-gray-200 rounded-t-md px-4 py-1 text-base font-bold hover:bg-gray-400 hover:cursor-pointer active:bg-gray-400 active:cursor-pointer text-gray-950 dark:bg-gray-400',
+            isActive && 'text-white bg-primary dark:bg-secondary',
           )}
         >
           {getLabel(label)}

--- a/shared/ui/ToastItem.tsx
+++ b/shared/ui/ToastItem.tsx
@@ -18,7 +18,7 @@ export default function ToastItem({ id, message, type }: Props) {
   return (
     <div
       className={twMerge(
-        'flex items-center justify-between min-w-50 px-4 py-2 rounded-lg shadow-md text-sm animate-slide-up',
+        'flex items-center justify-between min-w-50 px-4 py-2 rounded-lg shadow-md text-sm animate-slide-up text-gray-950',
         type === 'success' && 'bg-green-200',
         type === 'warn' && 'bg-orange-200 ',
         type === 'error' && 'bg-red-200 ',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./app/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  darkMode: 'class',
+  darkMode: 'media',
   content: ['./app/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},

--- a/widgets/day-word-list/ui/DayWordList.tsx
+++ b/widgets/day-word-list/ui/DayWordList.tsx
@@ -20,8 +20,8 @@ export default function DayList({ params }: Props) {
     queryFn: () => getClientDayWordList({ params }),
   })
   if (isLoading) return null
-  if (isError) return <EmptyData text="알 수 없는 오류가 발생하였습니다." mode="dark" />
-  if (!data?.ok) return <EmptyData text="데이터가 없습니다." mode="dark" />
+  if (isError) return <EmptyData text="알 수 없는 오류가 발생하였습니다." mode="light" />
+  if (!data?.ok) return <EmptyData text="데이터가 없습니다." mode="light" />
 
   return (
     <div className="flex flex-col">

--- a/widgets/day-word-list/ui/DayWordList.tsx
+++ b/widgets/day-word-list/ui/DayWordList.tsx
@@ -24,8 +24,8 @@ export default function DayList({ params }: Props) {
   if (!data?.ok) return <EmptyData text="데이터가 없습니다." mode="dark" />
 
   return (
-    <div className="flex flex-col ">
-      <div className="sticky top-18 z-40 y py-2 flex  justify-between bg-white">
+    <div className="flex flex-col">
+      <div className="sticky top-18 z-40 y py-2 flex justify-between bg-white dark:bg-gray-800">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <GotoQuizButton gotoQuiz={gotoQuiz} />
       </div>

--- a/widgets/quiz-container/ui/QuizContainer.tsx
+++ b/widgets/quiz-container/ui/QuizContainer.tsx
@@ -24,7 +24,7 @@ export default function QuizContainer({ data }: Props) {
   const USER_CURRENT_INDEX = currentIndex + 1
 
   return (
-    <div className="flex flex-col py-5 gap-5 items-center bg-secondary rounded-b-md rounded-r-md min-h-[calc(100dvh-140px)] w-full dark:bg-gray-700">
+    <>
       {isFinished ? (
         <>
           <ProgressBar current={USER_SCORE} total={TOTAL} value={(USER_SCORE / TOTAL) * 100} />
@@ -57,6 +57,6 @@ export default function QuizContainer({ data }: Props) {
           </div>
         </>
       )}
-    </div>
+    </>
   )
 }

--- a/widgets/quiz-container/ui/QuizContainer.tsx
+++ b/widgets/quiz-container/ui/QuizContainer.tsx
@@ -24,7 +24,7 @@ export default function QuizContainer({ data }: Props) {
   const USER_CURRENT_INDEX = currentIndex + 1
 
   return (
-    <div className="flex flex-col py-5 gap-5 items-center bg-secondary rounded-b-md rounded-r-md min-h-[calc(100dvh-140px)] w-full">
+    <div className="flex flex-col py-5 gap-5 items-center bg-secondary rounded-b-md rounded-r-md min-h-[calc(100dvh-140px)] w-full dark:bg-gray-700">
       {isFinished ? (
         <>
           <ProgressBar current={USER_SCORE} total={TOTAL} value={(USER_SCORE / TOTAL) * 100} />

--- a/widgets/theme-category-list/ui/ThemeCategoryList.tsx
+++ b/widgets/theme-category-list/ui/ThemeCategoryList.tsx
@@ -31,7 +31,7 @@ function ThemeCategoryList() {
             <CategoryButton label={item.theme} id={item.theme} />
           </div>
         ))}
-        {filteredData.length === 0 && <EmptyData text="검색결과가 없습니다" mode="light" />}
+        {filteredData.length === 0 && <EmptyData text="검색결과가 없습니다" mode="dark" />}
       </div>
     </div>
   )

--- a/widgets/theme-category-list/ui/ThemeCategoryList.tsx
+++ b/widgets/theme-category-list/ui/ThemeCategoryList.tsx
@@ -21,7 +21,7 @@ function ThemeCategoryList() {
 
   return (
     <div className="flex flex-col ">
-      <div className="sticky top-18 z-40 y py-3 flex items-center">
+      <div className="sticky top-18 z-40 y py-3 flex items-center bg-white dark:bg-gray-800 ">
         <SearchBar value={keyword} onChange={onInputChange} />
       </div>
 

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -16,8 +16,8 @@ function ThemeWordList({ params }: Props) {
   const gotoQuiz = useGotoQuiz({ params, label: 'theme' })
 
   if (isLoading) return null
-  if (isError) return <EmptyData text="알 수 없는 오류가 발생하였습니다." mode="dark" />
-  if (!wordList) return <EmptyData text="데이터가 없습니다." mode="dark" />
+  if (isError) return <EmptyData text="알 수 없는 오류가 발생하였습니다." mode="light" />
+  if (!wordList) return <EmptyData text="데이터가 없습니다." mode="light" />
 
   return (
     <div className="flex flex-col min-h-[calc(100dvh-160px)]">

--- a/widgets/theme-word-list/ui/ThemeWordList.tsx
+++ b/widgets/theme-word-list/ui/ThemeWordList.tsx
@@ -21,7 +21,7 @@ function ThemeWordList({ params }: Props) {
 
   return (
     <div className="flex flex-col min-h-[calc(100dvh-160px)]">
-      <div className="sticky top-18 z-40 y py-2 flex  justify-between bg-white">
+      <div className="sticky top-18 z-40 y py-2 flex  justify-between bg-white dark:bg-gray-800 ">
         <HideWordButton isHidden={isHidden} handleHideMeaning={handleHideMeaning} />
         <MoveToButton label="반의어 확인" icon={Check} onClick={gotoCheckOpposition} />
         {wordList && wordList.length > 3 && <GotoQuizButton gotoQuiz={gotoQuiz} />}


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- 다크 모드 지원 
<img width="1512" height="945" alt="image" src="https://github.com/user-attachments/assets/c7661ab4-4a28-4c8c-b691-5b9f76371dc9" />

- 네비게이션 isActive 조건 추가하여 퀴즈 페이지로 이동시, 네비게이션 활성화 
<img width="1512" height="945" alt="image" src="https://github.com/user-attachments/assets/ec912c33-81f1-47ad-aa03-f631ac2911f3" />

## 관련 이슈
- close #40 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
### 다크 모드 지원 
- Tailwind darkMode 설정을 `media` 방식으로 설정 
  -   `class` →`media` 방식으로 변경한 이유  
    -  서비스 특성상 모바일 유저 비중이 높을 것으로 예상됨 
    - 앱이 아닌 웹 서비스이기 때문에 다크 모드를 직접 제어하는 토글 UI는 제공하지 않고 OS / 브라우저 설정을 그대로 따르는 편이 더 자연스럽다고 판단
    