### PR TITLE
fix<Common>: 스크롤 시 콘텐츠가 네비게이션 위로 비침

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function RootLayout({
           <div className="flex justify-center">
             <div className="relative max-w-3xl w-full bg-white p-5 min-h-screen dark:bg-gray-900">
               <ToastContainer />
-              <div className="sticky top-0 z-50">
+              <div className="sticky top-0 z-50 bg-white dark:bg-gray-900">
                 <Suspense fallback={null}>
                   <Header />
                   <NavigationBar />


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
-  스크롤 시 콘텐츠가 네비게이션 위로 비침

## 관련 이슈
- close #49 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
-   원인 : 헤더를 감싸는 div를 sticky로 고정은 했지만 배경이 투명해서 아래 콘텐츠가 비쳐 보였음

- 수정: bg-white dark:bg-gray-900 추가 → 부모와 같은 배경색으로 가려줌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sticky header appearance with proper background colors in light and dark themes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->