### PR TITLE
refacotor<CssStyle, Button>: footer 피드백 요청 ui 변경 및 아이콘 버튼에 aria-label, title 추가 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react'
 import { QueryProvider } from '@/shared/provider'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getTranslations } from 'next-intl/server'
+import { Send } from 'lucide-react'
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('Metadata')
@@ -39,9 +40,20 @@ export default async function RootLayout({
               </div>
               <QueryProvider>{children}</QueryProvider>
               <GotoTopButton />
-              <footer className="mt-3 text-xs text-gray-400 text-center">
+              <footer className="flex flex-col justify-center items-center gap-2 mt-3 text-xs text-gray-400 text-center">
                 <p>© 2025 JeongJooKim</p>
-                <a href="https://github.com/KimJJRoSY/hinkor/issues">Issues & Feedback</a>
+                <span className="flex items-center gap-1">
+                  사용 중 문제가 있거나 의견이 있다면
+                  <a
+                    href="https://github.com/KimJJRoSY/hinkor/issues"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center ml-1 hover:border-b active:border-b cursor-pointer font-bold"
+                  >
+                    <Send size={12} /> 피드백 보내기
+                  </a>
+                  를 눌러주세요.
+                </span>
               </footer>
             </div>
           </div>

--- a/features/word-list/ui/WordItem.tsx
+++ b/features/word-list/ui/WordItem.tsx
@@ -30,7 +30,7 @@ export default function WordItem({ word, isHidden, isLast }: Props) {
       </span>
       <div className="flex-1 gap-2 items-start">
         <div className="flex gap-2 items-center">
-          <h3 className="font-bold text-lg ">{word.힌디어}</h3>
+          <h3 className="font-bold text-lg">{word.힌디어}</h3>
           <p className="flex-1 text-gray-400 text-xs">{word.힌디어한글발음}</p>
         </div>
 
@@ -42,7 +42,9 @@ export default function WordItem({ word, isHidden, isLast }: Props) {
       </div>
       <button
         onClick={() => onSpeak(word.힌디어)}
-        className="cursor-pointer hover:translate-y-0.5 p-2 rounded hover:bg-gray-200 active:bg-gray-200 "
+        className="cursor-pointer hover:translate-y-0.5 p-2 rounded hover:bg-gray-200 active:bg-gray-200"
+        aria-label={`${word.힌디어} 발음 듣기`}
+        title="발음 듣기"
       >
         <Speech className="w-4 text-gray-400" />
       </button>

--- a/shared/ui/GotoTopButton.tsx
+++ b/shared/ui/GotoTopButton.tsx
@@ -11,6 +11,8 @@ function GotoTopButton() {
     <button
       onClick={handleClick}
       className="fixed bottom-6 right-6 rounded-full bg-gray-300 p-2 text-center shadow-2xl cursor-pointer hover:bg-accent active:bg-accent"
+      aria-label="맨 위로 이동"
+      title="맨 위로 이동"
     >
       <ChevronUp className="text-gray-950" />
     </button>


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- footer 피드백 요청 ui 변경
- 음성 듣기 버튼, 맨 위로 이동 버튼 - aria-lable, title 추가 

## 관련 이슈
- close #11 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
###  footer 피드백 요청 ui 변경
- before 
<img width="347" height="53" alt="image" src="https://github.com/user-attachments/assets/e75dfcef-dfed-4319-a4aa-49218d40d21d" />


- after
<img width="347" height="53" alt="image" src="https://github.com/user-attachments/assets/0861fc4b-05e0-45c4-b66a-9759681987c8" />

  - '피드백 보내기' 클릭시, 레포지터리 이슈 페이로 이동 

### 음성 듣기 버튼, 맨 위로 이동 버튼 - aria-lable, title 추가 
음성 듣기 버튼, 맨 위로 이동하는 버튼은 아이콘 뿐이기 때문에 aria-lable, title 추가하여 접근성을 개선함 
<img width="100" height="66" alt="image" src="https://github.com/user-attachments/assets/b5700234-99c4-41ba-8ac3-2dfc6d4f8a3b" />
<img width="100" height="71" alt="스크린샷 2025-12-31 오후 3 20 58" src="https://github.com/user-attachments/assets/440a74e1-3ddb-4a60-bb8f-b95a5c705e03" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a feedback submission option in the footer, enabling users to easily share feedback.

* **Accessibility**
  * Enhanced button accessibility across the application with descriptive labels and tooltips to improve screen reader support and user interaction clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->