### PR TITLE
refactor<Quiz>: 퀴즈 결과 페이지에 단어 색상 추가 및 프로그래스바 수정 

### DIFF
--- a/features/word-list/ui/WordItem.tsx
+++ b/features/word-list/ui/WordItem.tsx
@@ -16,7 +16,7 @@ export default function WordItem({ word, isHidden, isLast }: Props) {
   return (
     <div
       className={twMerge(
-        'p-4 border-b border-gray-200 flex gap-2 items-start rounded dark:rounded-b-none',
+        'p-4 border-b border-gray-200 flex gap-2 items-start bg-white dark:bg-gray-800',
         isLast && 'border-none',
       )}
     >

--- a/widgets/quiz-container/ui/QuizContainer.tsx
+++ b/widgets/quiz-container/ui/QuizContainer.tsx
@@ -21,7 +21,6 @@ export default function QuizContainer({ data }: Props) {
   } = useQuiz({ data })
   const USER_SCORE = quizList.length - wrongList.length
   const TOTAL = quizList.length
-  const USER_CURRENT_INDEX = currentIndex + 1
 
   return (
     <>
@@ -37,11 +36,7 @@ export default function QuizContainer({ data }: Props) {
         </>
       ) : (
         <>
-          <ProgressBar
-            current={USER_CURRENT_INDEX}
-            total={TOTAL}
-            value={(USER_CURRENT_INDEX / TOTAL) * 100}
-          />
+          <ProgressBar current={currentIndex} total={TOTAL} value={(currentIndex / TOTAL) * 100} />
           <div className="flex flex-1 flex-col items-center justify-center gap-10">
             <QuizItem question={quizList[currentIndex].question} />
             <div className="flex flex-col gap-6 items-center">


### PR DESCRIPTION
## 작업 내용
<!--
- 해당 PR에서 구현/수정한 내용 요약
- 예: 로그인 API 연동, 프로필 이미지 업로드 버그 수정 등
-->
- WordItem에 배경색상 추가 
- ProgressBar에 넘겨주는  props를 currentIndex로 변경 

## 관련 이슈
- close #60 
- close #61 

## PR 설명
<!--
- 작업 상세 내용, 특이사항, 고민했던 점
- 예: JWT 토큰 처리 방식 변경, 이전 버그와의 차이 등
-->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated component styling to support light and dark mode with dedicated background colors, ensuring visual consistency across different theme preferences.

* **Refactor**
  * Simplified quiz progress tracking by streamlining calculation logic, improving accuracy of progress display without affecting score tracking functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->